### PR TITLE
fix bug in get_screen_resolution

### DIFF
--- a/AUICrawler/module/DeviceInfo.py
+++ b/AUICrawler/module/DeviceInfo.py
@@ -79,13 +79,13 @@ class Device:
 
     def get_screen_resolution(self):
         Saver.save_crawler_log(self.logPath, "Step : get screen resolution")
-        command = 'adb -s ' + self.id + ' shell wm size'
+        command = 'adb -s ' + self.id + ' shell dumpsys window'
         resolution = []
         result = os.popen(command).readlines()
         x = ''
         y = ''
         for line in result:
-            if 'Physical size: ' in line:
+            if 'init=' in line:
                 r = re.findall(r'\d+', line)
                 x = r[0]
                 y = r[1]


### PR DESCRIPTION
Get screen resolution successfully in:
1)Emulator--Android4.2
2)Emulator--Android6.0
3)Real Device--Samsung SM-G3502--Android4.2.2
4)Real Device--Samsung GT-I9152--Android4.2.2
5)Real Device--Huawei H60-L02--Android4.4.2